### PR TITLE
Refactor API routes to simplify endpoint paths

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -9,9 +9,9 @@ Route::get('/user', function (Request $request) {
   return $request->user();
 })->middleware('auth:sanctum');
 
-Route::get('/rnc/search', [RncController::class, 'advancedSearch']);
+Route::get('/search', [RncController::class, 'advancedSearch']);
 
-Route::post('/rnc/import', [RncImportController::class, 'import']);
+Route::post('/import', [RncImportController::class, 'import']);
 
 Route::get('/rnc-import/progress', function () {
   $progressFile = storage_path('app/import_progress.json');


### PR DESCRIPTION
- Changed '/rnc/search' to '/search' for improved clarity.
- Updated '/rnc/import' to '/import' to streamline the import process.

### 📎 Related Ticket

Issue #

No issue related to this change
---

### 📌 Change Summary

Brief description of the problem solved or improvement implemented:
Now the base URL for api is not `consultarnc.com.do/api/rnc/search`, now it is `consultarnc.com.do/api/search`

---

### ❌ Were there any changes outside the ticket scope?

-   [ ] Yes
-   [ ] No  
        If you marked "Yes", explain which ones:

---

### 🧪 Does this PR include automated tests?

-   [ ] Yes
-   [ ] No  
        If you marked "No", explain why:

---

### 📌 Additional Notes

Risks, technical decisions, dependencies, pending tasks, etc.:

---

### 🖼️ Screenshots (if applicable)

Include screenshots if applicable (UI, logs, fixed errors, etc.):
